### PR TITLE
Marshal PriorityQueue in Priority Order

### DIFF
--- a/pkg/datastructures/priorityqueue/priorityqueue.go
+++ b/pkg/datastructures/priorityqueue/priorityqueue.go
@@ -17,6 +17,12 @@ https://golang.org/pkg/container/heap/.
 
 package priorityqueue
 
+import (
+	"bytes"
+	"container/heap"
+	"encoding/json"
+)
+
 // An Item is something we manage in a Priority queue.
 type Item struct {
 	Value    interface{} // The Value of the item; arbitrary.
@@ -56,4 +62,32 @@ func (pq *PriorityQueue) Pop() interface{} {
 	item.index = -1 // for safety
 	*pq = old[0 : n-1]
 	return item
+}
+
+// Marshal a PriorityQueue in priorityqueue order.  Warning, this method is not terribly efficient, as iterating over a
+// heap-based PriorityQueue is destructive.  Thus, O(n) auxillary space is required to store the item references and
+// O(n) time complexity is needed to re-construct the priority queue post destruction.  There are likely more efficient
+// implementations, but in this case n is expected to remain sufficiently small, so this implementation is "good
+// enough".
+func (pq *PriorityQueue) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString("[")
+	pqLen := pq.Len()
+	var pqCopy []*Item
+	for i := 0; i < pqLen; i++ {
+		item := heap.Pop(pq).(*Item)
+		json, err := json.Marshal(*item)
+		if err != nil {
+			return nil, err
+		}
+        buffer.WriteString(string(json))
+		if i < pqLen - 1 {
+			buffer.WriteByte(',')
+		}
+		pqCopy = append(pqCopy, item)
+	}
+	buffer.WriteString("]")
+	for _, item := range pqCopy {
+		pq.Push(item)
+	}
+	return buffer.Bytes(), nil
 }

--- a/pkg/datastructures/priorityqueue/priorityqueue_test.go
+++ b/pkg/datastructures/priorityqueue/priorityqueue_test.go
@@ -14,7 +14,8 @@ package priorityqueue_test
 
 import (
 	"container/heap"
-	"github.com/ryandgoulding/datastructures/pkg/datastructures/priorityqueue"
+	"encoding/json"
+	"github.com/ryandgoulding/godatastructures/pkg/datastructures/priorityqueue"
 	"os"
 	"testing"
 )
@@ -111,6 +112,26 @@ func TestPriorityQueue_Pop(t *testing.T) {
 			if expected != actual {
 				t.Fatalf("%s: Expected: %s Actual %s", testCase.description, expected, actual)
 			}
+		}
+	}
+}
+
+func TestPriorityQueue_MarshalJSON(t *testing.T) {
+	// Simple re-entrance test.  MarshalJSON is destructive in this instance, since popping from a PriorityQueue is
+	// destructive.  Ensure that subsequent calls return the same result.
+	for _, testCase := range testCases {
+		firstJsonBytes, err := json.MarshalIndent(testCase.pq, "", "  ")
+		if err != nil {
+			t.Fatalf("Unexpected error marshaling JSON: %s", err)
+		}
+		firstJsonString := string(firstJsonBytes)
+		secondJsonBytes, err := json.MarshalIndent(testCase.pq, "", "  ")
+		if err != nil {
+			t.Fatalf("Unexpected error marshaling JSON: %s", err)
+		}
+		secondJsonString := string(secondJsonBytes)
+		if firstJsonString != secondJsonString {
+			t.Fatalf("Expected a match for: %s %s", firstJsonString, secondJsonString)
 		}
 	}
 }


### PR DESCRIPTION
Implements MarshalJSON to ensure a PriorityQueue is rendered by
iterating in order of priority.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>